### PR TITLE
Session

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.projectlombok:lombok:1.18.20'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
 
 	compileOnly 'org.projectlombok:lombok:1.18.20'
 	annotationProcessor 'org.projectlombok:lombok:1.18.20'

--- a/src/main/java/com/MindSpaceTeam/MindSpace/Config/RedisConfig.java
+++ b/src/main/java/com/MindSpaceTeam/MindSpace/Config/RedisConfig.java
@@ -7,8 +7,10 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration
+@EnableRedisHttpSession
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/MindSpaceTeam/MindSpace/Config/SecurityConfig.java
+++ b/src/main/java/com/MindSpaceTeam/MindSpace/Config/SecurityConfig.java
@@ -1,26 +1,20 @@
 package com.MindSpaceTeam.MindSpace.Config;
 
 import com.MindSpaceTeam.MindSpace.Filters.LoginAuthenticationFilter;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@Slf4j
 public class SecurityConfig {
-    @Value("${mindspace.jwt.secret-key}")
-    private String secretKey;
-
     @Bean
-    public SecurityFilterChain sercurityFilterChain(HttpSecurity httpSecurity) throws Exception {
-        LoginAuthenticationFilter loginAuthenticationFilter = new LoginAuthenticationFilter();
-        loginAuthenticationFilter.setSecretKey(secretKey);
-
+    public SecurityFilterChain sercurityFilterChain(HttpSecurity httpSecurity, LoginAuthenticationFilter loginAuthenticationFilter) throws Exception {
         return httpSecurity
                 .authorizeHttpRequests((authorize) ->
                     authorize


### PR DESCRIPTION
## 작업 개요

- 사용자 데이터 관리 기법 Token방식에서 Session방식으로 변경
-  Spring Security를 활용한 권한 체크 기능 추가

## 작업 내용

### 1. Token방식에서 Session방식으로 변경

사용자의 데이터를 저장하는 기법을 Stateless한 Token방식에서 Stateful한 Session방식으로 바꾼 이유는, 편집 데이터 처리를 담당하는 Socket서버에서는 WorkSpace에 입장하기 전 해당 사용자가 해당 WorkSpace에 접근할 수 있는 권한이 있는지 확인해야한다.

Token방식을 활용하더라도 RefreshToken은 Redis와 같은 공유 저장소에 Stateful하게 저장되어야 한다. 이는, 어차피 세션 기법과 마찬가지로 데이터 저장 및 유지해야 함이 동일하기 때문에 차라리 Socket의 연결을 서버에서 유지 및 원격 접속 해제하기 위해서는 세션 기법이 더 타당하다고 판단.

`redis`를 활용해 공유 저장소를 두었음

### 2. Spring Security를 활용한 권한 체크 기능

Spring Security를 활용해 `/workspaces`, `/workspace`에 해당하는 경로에 접근하는 경우는 사용자가 인증되어야 한다.

기존 Token방식으로 인증 여부를 판단한 동작 방식에서 Cookie에 담긴 SessionID가 Redis에 저장된 세션과 비교해 존재하는지, 유효한지 판별 후 인증된 사용자로 판단하도록 수정하였음

## 학습 내용

### 1. Spring Authentication

Spring Security에서는 인증된 사용자임을 나타내기 위해 `Authentication`클래스를 활용한다. 이는, `SecurityContextHolder`에 저장되며, `Authentication`은 `ThreadLocal`하기 때문에 스레드 별 관리되는 인스턴스는 달라진다.

<img width="486" height="179" alt="image" src="https://github.com/user-attachments/assets/d3fd2881-a0cc-444c-a184-59be72696041" />

또한, `Authentication`을 `SecurityContext`에 직접 넣어줘야 한다. 해당 작업은, 인증된 사용자임을 서버 내에 알리기 위해 설정해야 한다.(이는 각 요청마다 수행되어야 함)

```java
SecurityContext.getContext().setAuthentication(new TestingAuthenticationToken(principal, credential));
```

위와 같이 설정 가능하다.
